### PR TITLE
fix length of half-password

### DIFF
--- a/Signer.php
+++ b/Signer.php
@@ -44,7 +44,7 @@ class Signer
             $keyPassword = mb_substr(
                     $keyPassword,
                     0,
-                    ceil(mb_strlen($keyPassword, self::MB_ENCODING) / 2),
+                    floor(mb_strlen($keyPassword, self::MB_ENCODING) / 2),
                     self::MB_ENCODING
             );
             $keyBuffer = self::readKeyBuffer($keyData, $wmid, $keyPassword);


### PR DESCRIPTION
For the half-password case, when length of a password is odd, middle character should not be kept.
Haven't found any docs to prove that, but for me it works only that way.
